### PR TITLE
Patch to avoid crashing if feed a negative value.

### DIFF
--- a/ESP_MQTT_Digital_LEDs/ESP_MQTT_Digital_LEDs.ino
+++ b/ESP_MQTT_Digital_LEDs/ESP_MQTT_Digital_LEDs.ino
@@ -526,7 +526,7 @@ void loop() {
   FastLED.setBrightness(brightness);  //EXECUTE EFFECT COLOR
   FastLED.show();
 
-  if (animationspeed < 150) {  //Sets animation speed based on receieved value
+  if (animationspeed > 0 && animationspeed < 150) {  //Sets animation speed based on receieved value
     FastLED.delay(1000 / animationspeed);
   }
 


### PR DESCRIPTION
Feeding a negative value to the sketch for the `animationspeed` will cause the sketch freeze.
Quick workaround is a guard clause to test that the value is valid.

Haven't tested this on an actual strip since I only had my laptop with me.