### PR TITLE
Let HASS know the LEDs are off on startup.

### DIFF
--- a/ESP_MQTT_Digital_LEDs/ESP_MQTT_Digital_LEDs.ino
+++ b/ESP_MQTT_Digital_LEDs/ESP_MQTT_Digital_LEDs.ino
@@ -617,6 +617,7 @@ void reconnect() {
       client.subscribe(setpowersub);
       client.subscribe(seteffectsub);
       client.subscribe(setanimationspeed);
+      client.publish(setpowerpub, "OFF");
     } else {
       Serial.print("failed, rc=");
       Serial.print(client.state());


### PR DESCRIPTION
A very minor change, but as is, when the LEDs start up, HASS still thinks they are on. This lets HASS know that the LEDs are off.